### PR TITLE
Remove ../Config from #include "../Config/SEGGER_RTT_Conf.h"

### DIFF
--- a/RTT/SEGGER_RTT.h
+++ b/RTT/SEGGER_RTT.h
@@ -58,7 +58,7 @@ Revision: $Rev: 24324 $
 #ifndef SEGGER_RTT_H
 #define SEGGER_RTT_H
 
-#include "../Config/SEGGER_RTT_Conf.h"
+#include "SEGGER_RTT_Conf.h"
 
 /*********************************************************************
 *


### PR DESCRIPTION
so the porting could replace the configuration more easier
