### PR TITLE
Various improvements

### DIFF
--- a/RTT/SEGGER_RTT.h
+++ b/RTT/SEGGER_RTT.h
@@ -309,6 +309,17 @@ Revision: $Rev: 25842 $
 #define SEGGER_RTT__CB_SIZE                              (16 + 4 + 4 + (SEGGER_RTT_MAX_NUM_UP_BUFFERS * 24) + (SEGGER_RTT_MAX_NUM_DOWN_BUFFERS * 24))
 #define SEGGER_RTT__CB_PADDING                           (SEGGER_RTT__ROUND_UP_2_CACHE_LINE_SIZE(SEGGER_RTT__CB_SIZE) - SEGGER_RTT__CB_SIZE)
 
+#if defined(__GNUC__) || defined(__clang__)
+//   https://gcc.gnu.org/onlinedocs/gcc-4.7.2/gcc/Function-Attributes.html
+#    ifdef __MINGW_PRINTF_FORMAT
+#        define SEGGER_RTT_PRINTF_FORMAT(STRING_INDEX, FIRST_TO_CHECK) __attribute__ ((format (__MINGW_PRINTF_FORMAT, STRING_INDEX, FIRST_TO_CHECK)))
+#    else
+#        define SEGGER_RTT_PRINTF_FORMAT(STRING_INDEX, FIRST_TO_CHECK) __attribute__ ((format (printf, STRING_INDEX, FIRST_TO_CHECK)))
+#    endif // __MINGW_PRINTF_FORMAT
+#else
+#    define SEGGER_RTT_PRINTF_FORMAT(STRING_INDEX, FIRST_TO_CHECK)
+#endif
+
 /*********************************************************************
 *
 *       Types
@@ -439,7 +450,7 @@ int     SEGGER_RTT_TerminalOut        (unsigned char TerminalId, const char* s);
 *
 **********************************************************************
 */
-int SEGGER_RTT_printf(unsigned BufferIndex, const char * sFormat, ...);
+int SEGGER_RTT_printf(unsigned BufferIndex, const char * sFormat, ...) SEGGER_RTT_PRINTF_FORMAT(2, 3);
 int SEGGER_RTT_vprintf(unsigned BufferIndex, const char * sFormat, va_list * pParamList);
 
 #ifdef __cplusplus

--- a/RTT/SEGGER_RTT.h
+++ b/RTT/SEGGER_RTT.h
@@ -284,7 +284,6 @@ Revision: $Rev: 25842 $
 #endif
 
 #ifndef SEGGER_RTT_ASM  // defined when SEGGER_RTT.h is included from assembly file
-#include <stdlib.h>
 #include <stdarg.h>
 #include <stdint.h>
 


### PR DESCRIPTION
1. Only include string.h when SEGGER_RTT_MEMCPY is not defined
2. Fix memcpy being used in a couple places instead of SEGGER_RTT_MEMCPY
3. Remove stdlib.h include from SEGGER_RTT.h since it's not necessary (unused)
4. Add a new macro: SEGGER_RTT_PRINTF_FORMAT to let the compiler know SEGGER_RTT_printf is a printf function (the compiler will check for errors in printf calls)